### PR TITLE
fix: ignore udp stream error

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const getStream = (config) => {
       stream = { path: config.streamPath || './logs/app.log' };
       break;
     case 'SYSLOG':
-      let syslogStream = bsyslog.createBunyanStream({
+      const syslogStream = bsyslog.createBunyanStream({
         name: config.streamName,
         host: config.streamHost,
         port: parseInt(config.streamPort, 10),
@@ -42,8 +42,8 @@ const getStream = (config) => {
   return stream;
 };
 const ignoreUDPError = function (udpStream) {
-  udpStream.on('error', function() {
-    // do nothing here, ignore possible errors
+  udpStream.on('error', function(err) {
+    console.error('bunyan-syslog/UDPStream', err);
   });
 };
 

--- a/index.js
+++ b/index.js
@@ -27,12 +27,7 @@ const getStream = (config) => {
         facility: bsyslog.facility.local0,
         type: config.streamProto
       });
-      if (!config.streamProto // default type is udp, so undefined shall also be handled
-        || (
-          config.streamProto
-          && typeof config.streamProto === 'string'
-          && config.streamProto.toUpperCase() === 'UDP'
-        )) {
+      if (isProtoUDP(config)) {
         ignoreUDPError(syslogStream);
       }
       stream = {
@@ -46,10 +41,20 @@ const getStream = (config) => {
   }
   return stream;
 };
+
 const ignoreUDPError = function (udpStream) {
   udpStream.on('error', function(err) {
     console.error('bunyan-syslog/UDPStream', err);
   });
+};
+
+const isProtoUDP = function (config) {
+  return !config.streamProto // default type is udp, so undefined shall also be handled
+    || (
+      config.streamProto
+      && typeof config.streamProto === 'string'
+      && config.streamProto.toUpperCase() === 'UDP'
+    );
 };
 
 const noStackErrSerializers = function (err) {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const getStream = (config) => {
         type: config.streamProto
       });
       if (config.streamProto.toUpperCase() === 'UDP') {
-        syslogStream = replaceUdpSendFunc(syslogStream);
+        ignoreUDPError(syslogStream);
       }
       stream = {
         type: 'raw',
@@ -41,20 +41,10 @@ const getStream = (config) => {
   }
   return stream;
 };
-const replaceUdpSendFunc = function (udpStream) {
-  udpStream._send = function _send(msg) {
-    const buf = Buffer.from(msg, 'utf-8');
-    const s = this.socket;
-    const self = this;
-
-    this._pending++;
-    s.send(buf, 0, buf.length, this.port, this.host, function (err) {
-      // no err checking, just ignore it here
-      self._pending--;
-    });
-  };
-
-  return udpStream;
+const ignoreUDPError = function (udpStream) {
+  udpStream.on('error', function() {
+    // do nothing here, ignore possible errors
+  });
 };
 
 const noStackErrSerializers = function (err) {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,12 @@ const getStream = (config) => {
         facility: bsyslog.facility.local0,
         type: config.streamProto
       });
-      if (config.streamProto.toUpperCase() === 'UDP') {
+      if (!config.streamProto // default type is udp, so undefined shall also be handled
+        || (
+          config.streamProto
+          && typeof config.streamProto === 'string'
+          && config.streamProto.toUpperCase() === 'UDP'
+        )) {
         ignoreUDPError(syslogStream);
       }
       stream = {


### PR DESCRIPTION
Ignore the errors in udp stream, using `stream.on('error', ...);`